### PR TITLE
Bug fix: zstyle name typo; missing prefix for sourcing hooks

### DIFF
--- a/example_config.zsh
+++ b/example_config.zsh
@@ -36,24 +36,28 @@ zstyle ':prompt:*:fluttershy'   host-color 226
 zstyle ':vcs_info:*:powerline:*' check-for-changes true
 
 # if you are using the new powerline symbols, uncomment these lines.
-# zstyle ':prompt:powerline:ps1' sep1-char ''
-# zstyle ':prompt:powerline:ps1' sep2-char ''
-# zstyle ':prompt:powerline:ps1' lock-char ''
-# zstyle ':prompt:powerline:ps1' branch-char ''
+ zstyle ':prompt:powerline:ps1:' sep1-char ''
+ zstyle ':prompt:powerline:ps1:' sep2-char ''
+ zstyle ':prompt:powerline:ps1:' lock-char ''
+ zstyle ':prompt:powerline:ps1:' branch-char ''
+
+
+# added, otherwise hooks wouldn't be found
+SCRIPT_SOURCE=${0%/*}
 
 ### load some optional hooks which add further functionality. uncomment to enable.
 
 # disambiguate the pathname instead of last three elements (/u/s/z/functions -> share/zsh/functions)
-# source hooks/prompt-disambiguate.zsh
+ source $SCRIPT_SOURCE/hooks/prompt-disambiguate.zsh
 
 # show signal names instead of exit codes based on a heuristic (130 -> INT)
-# source hooks/prompt-exitnames.zsh
+ source $SCRIPT_SOURCE/hooks/prompt-exitnames.zsh
 
 # show commits ahead/behind of tracking branch, and number of stashed commits
-# source hooks/vcs_info-githooks.zsh
+ source $SCRIPT_SOURCE/hooks/vcs_info-githooks.zsh
 
 # show lo-fi version of vcs info, saving load times in exchange for information
-# source hooks/vcs_info-lofi.zsh
+ source $SCRIPT_SOURCE/hooks/vcs_info-lofi.zsh
 
 
 ### done with configuration - actually select the prompt

--- a/prompt_powerline_setup
+++ b/prompt_powerline_setup
@@ -76,10 +76,10 @@ prompt_powerline_precmd () {
 
     # have those here as well
     local sep1 sep2 lock_char branch_char
-    zstyle -s ':prompt:poweline:ps1:' sep1-char sep1 || sep1='⮀'
-    zstyle -s ':prompt:poweline:ps1:' sep2-char sep2 || sep2='⮁'
-    zstyle -s ':prompt:poweline:ps1:' lock-char lock_char || lock_char='⭤'
-    zstyle -s ':prompt:poweline:ps1:' branch-char branch_char || branch_char='⭠'
+    zstyle -s ':prompt:powerline:ps1:' sep1-char sep1 || sep1='⮀'
+    zstyle -s ':prompt:powerline:ps1:' sep2-char sep2 || sep2='⮁'
+    zstyle -s ':prompt:powerline:ps1:' lock-char lock_char || lock_char='⭤'
+    zstyle -s ':prompt:powerline:ps1:' branch-char branch_char || branch_char='⭠'
 
     # the variable we add our bits to
     prompt_bits=( )
@@ -200,10 +200,10 @@ a prompt with powerline patched font not supporting 256 colors is kind of a Rari
     fi
 
     local sep1 sep2 lock_char branch_char
-    zstyle -s ':prompt:poweline:ps1:' sep1-char sep1 || sep1='⮀'
-    zstyle -s ':prompt:poweline:ps1:' sep2-char sep2 || sep2='⮁'
-    zstyle -s ':prompt:poweline:ps1:' lock-char lock_char || lock_char='⭤'
-    zstyle -s ':prompt:poweline:ps1:' branch-char branch_char || branch_char='⭠'
+    zstyle -s ':prompt:powerline:ps1:' sep1-char sep1 || sep1='⮀'
+    zstyle -s ':prompt:powerline:ps1:' sep2-char sep2 || sep2='⮁'
+    zstyle -s ':prompt:powerline:ps1:' lock-char lock_char || lock_char='⭤'
+    zstyle -s ':prompt:powerline:ps1:' branch-char branch_char || branch_char='⭠'
 
     # load vcs_info styles
     autoload -Uz vcs_info


### PR DESCRIPTION
Hi Valodim, I fixed some minor bugs in the scripts:
1. for the zstyle commands, some "powerline" are mistyped as "poweline"; and a trailing ':' is missing from some of them
2. when example_config.zsh is sourced from a script in another dir e.g. ~/.zshrc, the paths for hooks need to be prefixed by the parent dir of the config.zsh file
