### PR TITLE
Fixed configuration spelling error

### DIFF
--- a/prompt_powerline_setup
+++ b/prompt_powerline_setup
@@ -76,10 +76,10 @@ prompt_powerline_precmd () {
 
     # have those here as well
     local sep1 sep2 lock_char branch_char
-    zstyle -s ':prompt:poweline:ps1:' sep1-char sep1 || sep1='⮀'
-    zstyle -s ':prompt:poweline:ps1:' sep2-char sep2 || sep2='⮁'
-    zstyle -s ':prompt:poweline:ps1:' lock-char lock_char || lock_char='⭤'
-    zstyle -s ':prompt:poweline:ps1:' branch-char branch_char || branch_char='⭠'
+    zstyle -s ':prompt:powerline:ps1:' sep1-char sep1 || sep1='⮀'
+    zstyle -s ':prompt:powerline:ps1:' sep2-char sep2 || sep2='⮁'
+    zstyle -s ':prompt:powerline:ps1:' lock-char lock_char || lock_char='⭤'
+    zstyle -s ':prompt:powerline:ps1:' branch-char branch_char || branch_char='⭠'
 
     # the variable we add our bits to
     prompt_bits=( )
@@ -200,10 +200,10 @@ a prompt with powerline patched font not supporting 256 colors is kind of a Rari
     fi
 
     local sep1 sep2 lock_char branch_char
-    zstyle -s ':prompt:poweline:ps1:' sep1-char sep1 || sep1='⮀'
-    zstyle -s ':prompt:poweline:ps1:' sep2-char sep2 || sep2='⮁'
-    zstyle -s ':prompt:poweline:ps1:' lock-char lock_char || lock_char='⭤'
-    zstyle -s ':prompt:poweline:ps1:' branch-char branch_char || branch_char='⭠'
+    zstyle -s ':prompt:powerline:ps1:' sep1-char sep1 || sep1='⮀'
+    zstyle -s ':prompt:powerline:ps1:' sep2-char sep2 || sep2='⮁'
+    zstyle -s ':prompt:powerline:ps1:' lock-char lock_char || lock_char='⭤'
+    zstyle -s ':prompt:powerline:ps1:' branch-char branch_char || branch_char='⭠'
 
     # load vcs_info styles
     autoload -Uz vcs_info


### PR DESCRIPTION
There was a spelling error in the prompt_powerline_setup file, causing the configuration that allowed users to change their powerline characters to break.
